### PR TITLE
Update server.cfg

### DIFF
--- a/CallOfDuty4/server.cfg
+++ b/CallOfDuty4/server.cfg
@@ -24,7 +24,7 @@ sets _Gametype ""
 set sv_hostname "SERVERNAME"
 set g_motd "" // Message of the day, which getting shown to every player on his 1st spawn
 set dedicated "2" 	// 0 = Listen, 1 = LAN, 2 = Internet ( you probably want 2 )
-set rcon_password "ADMINPASSWORD"  // password for remote access, leave empty to deactivate, min 8 characters
+set rcon_password ""  // password for remote access, leave empty to deactivate, min 8 characters
 set g_password ""     // join password, leave empty to deactivate
 set sv_privateClients "2" //Private Clients, number of slots that can only be changed with a password
 set sv_privatePassword "mypassword"  // the password to join private slots


### PR DESCRIPTION
should be removed to prevent accidental use of a standard password on a live server.
keeping the password empty deactivates rcon access.