### PR TITLE
Add sv_tags to CS:GO server config

### DIFF
--- a/CounterStrikeGlobalOffensive/server.cfg
+++ b/CounterStrikeGlobalOffensive/server.cfg
@@ -24,6 +24,10 @@ sv_contact ""
 // Default: sv_lan 0
 sv_lan 0
 
+// Tags - Used to provide extra information to clients when they're browsing for servers. Separate tags with a comma.
+// Example: sv_tags "128tick,deathmatch,dm,ffa,pistol,dust2"
+sv_tags ""
+
 // ............................. Server Logging ............................. //
 
 // Enable log - Enables logging to file, console, and udp < on | off >.


### PR DESCRIPTION
Server tags. Used to provide extra information to clients when they're browsing for servers. Separate tags with a comma.

Shows up here, in the Community Server Browser:
![image](https://user-images.githubusercontent.com/1230402/56899772-993b1180-6a94-11e9-805f-67cf659d2e99.png)