### PR TITLE
updated sv_cheats

### DIFF
--- a/CounterStrikeGlobalOffensive/server.cfg
+++ b/CounterStrikeGlobalOffensive/server.cfg
@@ -1,7 +1,7 @@
 // ************************************************************************** //
 //                                                                            //
 //     Counter-Strike: Global Offensive - server.cfg                          //
-//     Version 240917                                                         //
+//     Version 120719                                                         //
 //                                                                            //
 // ************************************************************************** //
 
@@ -24,8 +24,13 @@ sv_contact ""
 // Default: sv_lan 0
 sv_lan 0
 
+// Cheats mode - Server is disabled to use cheats by default;Commands like noclip,god are disabled to be exploited by the players. VAC (Valve Anti-Cheat) is disabled in this mode when value is set to '1'.
+// Default: sv_cheats 0
+// Cheats ON: sv_cheats 1
+sv_cheats 0
+
 // Tags - Used to provide extra information to clients when they're browsing for servers. Separate tags with a comma.
-// Example: sv_tags "128tick,deathmatch,dm,ffa,pistol,dust2"
+// Example: sv_tags "128-tick,deathmatch,dm,ffa,pistol,dust2"
 sv_tags ""
 
 // ............................. Server Logging ............................. //


### PR DESCRIPTION
updated the `sv_cheats 0` command to default config files in `CounterStrikeGlobalOffensive/server.cfg` with proper documentation as requested by the issues tab in [LinuxGSM #2031](https://github.com/GameServerManagers/LinuxGSM/issues/2031)