### PR TITLE
Add sv_region to csgoserver

### DIFF
--- a/CounterStrikeGlobalOffensive/server.cfg
+++ b/CounterStrikeGlobalOffensive/server.cfg
@@ -33,6 +33,11 @@ sv_cheats 0
 // Example: sv_tags "128-tick,deathmatch,dm,ffa,pistol,dust2"
 sv_tags ""
 
+// Region - The region of the world to report this server in.
+// Default: -1
+// 0 - US East, 1 - US West, 2 - South America, 3 - Europe, 4 - Asia, 5 - Australia, 6 - Middle East, 7 - Africa
+sv_region -1
+
 // ............................. Server Logging ............................. //
 
 // Enable log - Enables logging to file, console, and udp < on | off >.


### PR DESCRIPTION
From [developer.valvesoftware.com](https://developer.valvesoftware.com/wiki/Sv_region):

> This cvar might be deprecated, it has been removed from the HLDS (but still exists in SRCDS) and the Steam server browser doesn't have an option to select a region any more. (Though the in-game server browser might still have this option.)

> Please note:
> 
> - If sv_region is set to a specific region (0 to 7) then the server will be listed if this region or "< All >" is selected in the Steam server browser's location filter.
> - If sv_region is set to anything else then the server will only be listed if "< All >" is selected in the Steam server browser's location filter.

And yes, the in-game server browser still have this option.