### PR TITLE
fix: update Colony Survival config for version 0.8.1

### DIFF
--- a/ColonySurvival/colserver.json
+++ b/ColonySurvival/colserver.json
@@ -1,7 +1,6 @@
 {
 	"NewOptions" : {
-		"WorldName" : "colserver",
-		"Seed" : "RNDSEED"
+		"WorldName" : "colserver"
 	},
 	"ServerSettings" : {
 		"ServerName" : "SERVERNAME",


### PR DESCRIPTION
Remove Random Seed because it is not longer needed.

From the changelog:

> - Generate a random seed if none is provided via the JSON-config launch option