### PR TITLE
feature(rust): add server tags in the default config

### DIFF
--- a/Rust/server.cfg
+++ b/Rust/server.cfg
@@ -21,6 +21,12 @@ server.url "https://linuxgsm.com/"
 # Optional Settings You Can Change #
 ####################################
 
+# Tags are additional bits of information that describe Rust servers.
+# Up to three of them will be displayed on the Rust server browser and filtering will be supported one day.
+# Supported Tags can be found here:
+# https://wiki.facepunch.com/rust/server-browser-tags
+#server.tags 
+
 # A value of false makes text chat location based only (players need to be close to each other).
 # Values: true, false
 #server.globalchat true


### PR DESCRIPTION
Adds the server.tags to the default config
Doc: https://wiki.facepunch.com/rust/server-browser-tags