### PR TITLE
fix: Added IpServer.UdpServerUplink section

### DIFF
--- a/UnrealTournament99/Default.ini
+++ b/UnrealTournament99/Default.ini
@@ -245,6 +245,10 @@ SimLatency=0
 [IpServer.UdpServerQuery]
 GameName=ut
 
+[IpServer.UdpServerUplink]
+DoUplink=True
+UpdateMinutes=1
+
 [IpDrv.UdpBeacon]
 DoBeacon=True
 BeaconTime=0.50


### PR DESCRIPTION
This section is missing from the default config file which is required for the server to report to master servers listed in the ServerActors declaration of the Engine.GameEngine section of the config file.