### PR TITLE
Fistful of Frags: Default maxplayers 16

### DIFF
--- a/FistfulofFrags/server.cfg
+++ b/FistfulofFrags/server.cfg
@@ -13,6 +13,9 @@ hostname "SERVERNAME"
 // RCON - remote console password.
 rcon_password "ADMINPASSWORD"
 
+// Max players - 16 max for FFA
+maxplayers 16
+
 // Server password - for private servers.
 sv_password ""
 


### PR DESCRIPTION
Added maxplayers to config and set value to 16 to allow FFA to work properly.
Default server config is broken and only allows 1 map to be played.