### PR TITLE
Necesse

### DIFF
--- a/Necesse/worldSettings.cfg
+++ b/Necesse/worldSettings.cfg
@@ -9,6 +9,5 @@ WORLDSETTINGS = {
 	unloadSettlements = false,
 	maxSettlementsPerPlayer = -1,
 	dayTimeMod = 1.0, // Day time modifier (The higher, the longer day will last, max 10)
-	nightTimeMod = 1.0, // Night time modifier (The higher, the longer night will last, max 10)
-	gameVersion = 0.21.25
+	nightTimeMod = 1.0, // Night time modifier (The higher, the longer night will last, max 10)	
 }

--- a/Necesse/worldSettings.cfg
+++ b/Necesse/worldSettings.cfg
@@ -1,0 +1,14 @@
+WORLDSETTINGS = {
+	allowCheats = false,
+	difficulty = NORMAL,
+	deathPenalty = DROP_MATS,
+	raidFrequency = OCCASIONALLY,
+	playerHunger = true,
+	disableMobSpawns = false,
+	forcedPvP = false, // True = players will always have PvP enabled
+	unloadSettlements = false,
+	maxSettlementsPerPlayer = -1,
+	dayTimeMod = 1.0, // Day time modifier (The higher, the longer day will last, max 10)
+	nightTimeMod = 1.0, // Night time modifier (The higher, the longer night will last, max 10)
+	gameVersion = 0.21.25
+}


### PR DESCRIPTION
This adds default settings `worldSettings.cfg` for Necesse dedicated servers

Depending on how the server is configured, Necess may look for configs in a zipfile or a directory.  See "File Locations" at https://necessewiki.com/Multiplayer-Linux

Generally, Necesse will look for `worldSettings.cfg` in one of two places (based on server configuration): 

- if `zipSaves = true`: ~/.config/Necesse/saves/**[worldname].zip**/worldSettings.zip

- if `zipSaves = false`: ~/.config/Necesse/saves/[worldname]/worldSettings.cfg

Related issue: https://github.com/GameServerManagers/LinuxGSM/issues/3852