### PR TITLE
Switch to OpenSpy master server for Unreal Tournament 2004

### DIFF
--- a/UnrealTournament2004/UT2004.ini
+++ b/UnrealTournament2004/UT2004.ini
@@ -269,8 +269,7 @@ ServerBehindNAT=False
 [IpDrv.MasterServerLink]
 LANPort=11777
 LANServerPort=10777
-MasterServerList=(Address="ut2004master1.epicgames.com",Port=28902)
-MasterServerList=(Address="ut2004master2.epicgames.com",Port=28902)
+MasterServerList=(Address="utmaster.openspy.net",Port=28902)
 
 [IpDrv.HTTPDownload]
 RedirectToURL=

--- a/UnrealTournament2004/UT2004.ini
+++ b/UnrealTournament2004/UT2004.ini
@@ -271,9 +271,6 @@ LANPort=11777
 LANServerPort=10777
 MasterServerList=(Address="ut2004master1.epicgames.com",Port=28902)
 MasterServerList=(Address="ut2004master2.epicgames.com",Port=28902)
-MasterServerList=(Address="master.333networks.com",Port=27900)
-MasterServerList=(Address="master.errorist.tk",Port=27900)
-MasterServerList=(Address="master.newbiesplayground.net",Port=27900)
 
 [IpDrv.HTTPDownload]
 RedirectToURL=


### PR DESCRIPTION
Epic Games is shutting down their server list backend on Jan 24th. The only currently available alternative is OpenSpy.

See GameServerManagers/LinuxGSM#4086

I also noticed that the existing default config had some GameSpy master server configured for UT2004. However, UT2004 uses a totally different protocol to communicate with master servers.

Overall these changes:
* Remove the soon defunct Epic Games master servers
* Remove the incompatible GameSpy master servers
* Add the OpenSpy Unreal Tournament master server

I will open a PR in the docs repo to add a hint to the UT2004 docs.