### PR TITLE
feat(jbep3): add default server config

### DIFF
--- a/jbep3/server.cfg
+++ b/jbep3/server.cfg
@@ -1,0 +1,51 @@
+// ****************************************************************************
+// Jabroni Brawl: Episode 3
+// Config - server.cfg
+// ****************************************************************************
+
+// This config is based on the game's sample config and uses LinuxGSM tokens.
+
+// -----------------------
+// Generic Source commands
+// -----------------------
+
+log on // Enable server logging
+
+hostname "SERVERNAME" // Server name
+
+rcon_password "ADMINPASSWORD" // RCON password
+
+mp_timelimit 30 // Map time limit in minutes
+mp_maxrounds 0 // Max number of rounds till level change
+
+mp_mapcycle_empty_timeout_seconds 300
+
+sv_downloadurl "" // Fast Download location
+
+// Load bans from previous sessions
+execifexists banned_ip.cfg
+execifexists banned_user.cfg
+
+// -----------------------
+// Jabroni Brawl voting
+// -----------------------
+
+jb_sv_voting_enabled 1 // Allow end of game voting
+
+// Voting fallback behavior.
+// 0 = Remain on same game mode, continue standard cycle.
+// 1 = Remain on same game mode/map.
+// 2 = Pick a random game mode/map.
+jb_sv_voting_fallback 0
+
+jb_sv_voting_allow_gamemode 1 // Enable/disable game mode voting
+jb_sv_voting_allow_map 1 // Enable/disable map voting
+
+// -----------------------
+// Jabroni Brawl other
+// -----------------------
+
+// Mapcycle method.
+// 0 = Sequential, standard Source behavior.
+// 1 = Randomized, picks random maps in the cycle.
+jb_sv_mapcycle_method 1


### PR DESCRIPTION
## Description
Adds a default `server.cfg` for Jabroni Brawl: Episode 3.

## Notes
- Based on the game-provided sample config.
- Includes LinuxGSM placeholders `SERVERNAME` and `ADMINPASSWORD`.
