### PR TITLE
Standardize Quake server.cfg style and section order

### DIFF
--- a/q2/server.cfg
+++ b/q2/server.cfg
@@ -1,15 +1,50 @@
+// ************************************************************************** //
+//                                                                            //
+//     Quake II - server.cfg                                                  //
+//     Version 260426                                                         //
+//                                                                            //
+// ************************************************************************** //
+
+// .................................. Basic ................................. //
+
+// hostname - Name of the server.
 set hostname "SERVERNAME"
+
+// rcon_password - Remote console password.
 set rcon_password "ADMINPASSWORD"
+
+// location - Server location shown in listings.
 set location "The Internet"
+
+// website - Server website URL.
 set website "https://linuxgsm.com"
-set deathmatch 1
-set maxclients 8
-set timelimit 30
-set fraglimit 30
 
-map q2dm1
+// ................................. Discovery ............................... //
 
+// public - Advertise this server publicly.
 set public 1
+
+// setmaster - Master servers used for server listing.
 setmaster master.q2servers.com:27900
 setmaster master.quakeservers.net:27900
 setmaster netdome.biz:27900
+
+// ................................ Gameplay ................................ //
+
+// deathmatch - Enable deathmatch rules.
+set deathmatch 1
+
+// maxclients - Maximum number of connected players.
+set maxclients 8
+
+// timelimit - Time limit in minutes.
+set timelimit 30
+
+// fraglimit - Frag limit per match.
+set fraglimit 30
+
+// ............................. Startup Commands ........................... //
+
+// This server uses a single startup map rather than a rotation chain.
+// map - Startup map.
+map q2dm1

--- a/q3/server.cfg
+++ b/q3/server.cfg
@@ -1,12 +1,24 @@
-set sv_hostname "SERVERNAME"
-set sv_maxclients 16
-set g_motd "Quake3 Server"
-set g_forcerespawn 15
-set rconpassword "ADMINPASSWORD"
-set g_gametype 0 //- Sets the type of game. 0 - Free for all, 1 - Tournament, 2 - Free for all(again), 3 - Team Deathmatch, 4 - Capture the Flag
-set fraglimit 50
-set timelimit 20
+// ************************************************************************** //
+//                                                                            //
+//     Quake III Arena - server.cfg                                           //
+//     Version 260426                                                         //
+//                                                                            //
+// ************************************************************************** //
 
+// .................................. Basic ................................. //
+
+// sv_hostname - Name of the server.
+set sv_hostname "SERVERNAME"
+
+// rconpassword - Remote console password.
+set rconpassword "ADMINPASSWORD"
+
+// g_motd - Message shown to connecting players.
+set g_motd "Quake3 Server"
+
+// ................................. Discovery ............................... //
+
+// sv_master1..sv_master5 - Master servers used for server listing.
 set sv_master1 "master3.idsoftware.com:27950"
 set sv_master2 "master.ioquake3.org:27950"
 set sv_master3 "master0.excessiveplus.net:27950"
@@ -14,8 +26,27 @@ set sv_master4 "master.maverickservers.com:27950"
 set sv_master5 "dpmaster.deathmask.net:27950"
 ; set sv_master2 "master.huxxer.de:27950"
 
-//Here's the map-cycle. When fraglimit or timelimit is reached, the map is automatically changed.
-//Otherwise it would just play the same map again.
+// ................................ Gameplay ................................ //
+
+// sv_maxclients - Maximum number of connected players.
+set sv_maxclients 16
+
+// g_forcerespawn - Auto-respawn delay in seconds.
+set g_forcerespawn 15
+
+// g_gametype - Game type.
+// 0 = Free For All, 1 = Tournament, 2 = Free For All, 3 = Team Deathmatch, 4 = Capture the Flag
+set g_gametype 0
+
+// fraglimit - Frag limit per match.
+set fraglimit 50
+
+// timelimit - Time limit in minutes.
+set timelimit 20
+
+// .............................. Map Rotation .............................. //
+
+// Map cycle. When fraglimit or timelimit is reached, the server changes map.
 set m1 "map q3dm1; set nextmap vstr m2"
 set m2 "map q3dm2; set nextmap vstr m3"
 set m3 "map q3dm3; set nextmap vstr m4"
@@ -41,5 +72,8 @@ set m22 "map q3dm17; set nextmap vstr m23"
 set m23 "map q3dm18; set nextmap vstr m24"
 set m24 "map q3dm19; set nextmap vstr m25"
 set m25 "map q3tourney6; set nextmap vstr m1"
-//Begin the map cycle at m1
+
+// ............................. Startup Commands ........................... //
+
+// Begin the map cycle at m1.
 vstr m1

--- a/q4/server.cfg
+++ b/q4/server.cfg
@@ -1,4 +1,11 @@
-// General Server Settings
+// ************************************************************************** //
+//                                                                            //
+//     Quake 4 - server.cfg                                                   //
+//     Version 260426                                                         //
+//                                                                            //
+// ************************************************************************** //
+
+// .................................. Basic ................................. //
 // sets the server name.
 seta si_name "SERVERNAME"
 // sets the remote console password for the server.
@@ -16,13 +23,13 @@ seta serverInfo ""
 // The maximum players that can join the server.
 seta si_maxPlayers "16"
 
-// Game Settings
+// ................................ Gameplay ................................ //
 seta si_gameType "DM" // Sets the type of game. Options are DM, Team DM, CTF, Arena CTF, or Tourney.
 seta si_autobalance "1" // 1=on 0=off - when enabled this will autobalance player to each team.
 seta si_shuffle "0" // 1=on 0=off - Shuffles the teams after each round. Only applicable to team games (TeamDM,CTF, ArenaCTF). Set to 1 to enable, 0 to disable.
 seta si_spectators "1" // 1=on 0=off - Allows spectators when enabled or forces all connected clients to play.
-seta si_teamDamage "0" // 1=on 0=off - when enabled teamates will be able to hurt each other.
-seta si_warmup "1" // 1=on 0=off - when enabled this sets the server to ruin a warmup period before match play begins.
+seta si_teamDamage "0" // 1=on 0=off - when enabled teammates will be able to hurt each other.
+seta si_warmup "1" // 1=on 0=off - when enabled this sets the server to run a warmup period before match play begins.
 seta si_allowVoting "0" // 1=on 0=off - allows player voting.
 seta g_spectatorChat "0" // 1=on 0=off - allows spectators to chat in-game.
 seta si_useReady "0" // 1=on 0=off - Forces players to select "Ready" before starting a match.
@@ -32,29 +39,32 @@ seta si_allowHitScanTint "0" // Enables custom railgun tinting color for players
 //1 - player hitscan tinting allowed in DM and NO hitscan tinting in team games
 //2 - player hitscan tinting allowed in DM and use team-color hitscan tints in
 
-//Team Games
+// ............................ Team Game Limits ............................ //
 seta si_fragLimit "100" // Sets the number of kills a player must get in order to win the round. When set to 0, there is no frag limit.
 seta si_timeLimit "0" // Sets the round's time limit in minutes. When set to 0, there is no time limit.
 seta si_tourneyLimit "3" // The number of times a tourney will use the same map before changing the map.
 seta si_captureLimit "10" // The number of flag captures needed to win a CTF or ArenaCTF match.
 
-//Rates
+// ................................ Network ................................ //
 //seta net_clientMaxRate "16000"
 //seta net_serverMaxClientRate "10000"
 
-//Punkbuster Settings
+// ................................. Security ................................ //
 seta sv_punkbuster "0" // 1=enabled 0=disabled
 
-//Map Settings
+// .............................. Map Rotation .............................. //
 //seta si_mapCycle "" // Creates a list of maps to cycle. It requires a semicolon-delimited list, such as "mp/q4dm1.map;mp/q4dm2.map;mp/q4dm2.map". It takes priority over the mapcycle.scriptcfg file.
 seta si_map "mp/q4dm1.map"   // sets the starting map
 seta g_mapCycle "mapcycle" // Sets the server's map cycling script. Defaults to mapcycle.scriptcfg. This file is located in the Q4base directory.
 
-//Game Modes - Execute game mode configs
+// .............................. Mode Includes ............................. //
+// Execute game mode configs.
 //exec dm.cfg
 //exec ctf.cfg
 //exec teamdm.cfg
 //exec tourney.cfg
+
+// ............................. Startup Commands ........................... //
 
 // start the server
 spawnServer

--- a/ql/server.cfg
+++ b/ql/server.cfg
@@ -13,7 +13,7 @@
 
 // Be aware that factories can override any cvar, including ones specified in this config file.
 
-// ............................. Basic Settings ............................. //
+// .................................. Basic ................................. //
 
 // Hostname for server.
 set sv_hostname "SERVERNAME"
@@ -27,27 +27,7 @@ set g_password ""
 // example: sv_tags "custom, classic"
 set sv_tags ""
 
-// ............................... Map Cycles ............................... //
-
-// info: The .txt file used to cycle the maps on servers.
-// There are several predefined mapcycles available that are listed below.
-// You can also create your own custom mapcycle.
-// "mappool.txt" - all maps
-// "mappool_ca.txt" - Clan Arena
-// "mappool_ctf.txt" - Capture the Flag
-// "mappool_duel.txt" - Duel
-// "mappool_ffa.txt" - Free for All
-// "mappool_race.txt" - Race
-// "mappool_tdm.txt" - Team Death Match
-set sv_mapPoolFile "mappool.txt"
-
-// Default map
-// Random Map - startRandomMap
-// Specific map (factory is required) - map campgrounds ffa
-// Default: set serverstartup "startRandomMap"
-set serverstartup "startRandomMap"
-
-// ............................ Client Settings ............................. //
+// .............................. Client Slots .............................. //
 
 // Number of player slots available.
 // Default: set sv_maxClients "16"
@@ -158,7 +138,7 @@ set net_strict "1"
 // Default: set sv_serverType "2"
 set sv_serverType "2"
 
-// ................................ Remote Admin ................................ //
+// ............................... Remote Admin ............................... //
 
 // Enable remote console, provided through ZeroMQ. See zmq_rcon.py for simple client.
 // ZMQ rcon binds on a separate port from the game server, and uses TCP. It must differ from the stats port if used.
@@ -198,7 +178,7 @@ set zmq_stats_enable "0"
 
 // Flood protection will increment everytime the user sends a client command.
 // Excluding: dropweapon, changing name, color, model, or chatting.
-// Set g_floodprot_maxcount to 0 to disable flood protection, but this not reccomended.
+// Set g_floodprot_maxcount to 0 to disable flood protection, but this is not recommended.
 
 // Kick a player when their userinfo flood counter reaches this level.
 // Default: set g_floodprot_maxcount "10"
@@ -216,9 +196,9 @@ set g_floodprot_decay "1000"
 // Used to determine which 64-bit Steam IDs have admin access, or are banned.
 set g_accessFile "access.txt"
 
-// ................................ System Settings ................................ //
+// .............................. System Settings .............................. //
 
-// Show in server browser and respond to queries. This will also affect the LAN Broswer
+// Show in server browser and respond to queries. This will also affect the LAN browser.
 // Default: set sv_master "1"
 set sv_master "1"
 
@@ -232,3 +212,25 @@ set sv_idleExit "120"
 
 // May need to be increased for additional players.
 set com_hunkMegs "60"
+
+// .............................. Map Rotation .............................. //
+
+// info: The .txt file used to cycle the maps on servers.
+// There are several predefined mapcycles available that are listed below.
+// You can also create your own custom mapcycle.
+// "mappool.txt" - all maps
+// "mappool_ca.txt" - Clan Arena
+// "mappool_ctf.txt" - Capture the Flag
+// "mappool_duel.txt" - Duel
+// "mappool_ffa.txt" - Free for All
+// "mappool_race.txt" - Race
+// "mappool_tdm.txt" - Team Death Match
+set sv_mapPoolFile "mappool.txt"
+
+// ............................. Startup Commands ........................... //
+
+// Default startup command.
+// Random map: startRandomMap
+// Specific map (factory required): map campgrounds ffa
+// Default: set serverstartup "startRandomMap"
+set serverstartup "startRandomMap"

--- a/qw/server.cfg
+++ b/qw/server.cfg
@@ -1,34 +1,55 @@
-// server info
-// server name shown in server browsers
-hostname                        "SERVERNAME" 
-rcon_password                   "ADMINPASSWPRD"
-// admin name shown in server browsers
-sv_admininfo                    "LinuxGSM <linuxgsm@example.com>" 
+// ************************************************************************** //
+//                                                                            //
+//     QuakeWorld - server.cfg                                                //
+//     Version 260426                                                         //
+//                                                                            //
+// ************************************************************************** //
 
-// motd (max 15 rows) - this is the welcome message displayed when you connect to a server
+// .................................. Basic ................................. //
+
+// hostname - Server name shown in server browsers.
+hostname                        "SERVERNAME"
+
+// rcon_password - Remote console password.
+rcon_password                   "ADMINPASSWORD"
+
+// sv_admininfo - Admin name shown in server browsers.
+sv_admininfo                    "LinuxGSM <linuxgsm@example.com>"
+
+// ............................. Server Message ............................. //
+
+// k_motd1..k_motd4 - Welcome message (max 15 rows).
 set	k_motd1                     "SERVERNAME"
 set	k_motd2                     " "
 set	k_motd3                     "Available game modes:"
 set	k_motd4                     "1on1, 2on2, 4on4, 10on10, ffa, ctf"
 
-// time motd is displayed in seconds
+// k_motd_time - Seconds MOTD is displayed.
 set k_motd_time                 "5"
 
+// ................................ Gameplay ................................ //
 
-// edit the lines below if you want different gamemodes on this port
-// matchless mode
-// run ktx as a regular match server or as a matchless (ffa) server (0 = regular, 1 = matchless)
+// k_matchless - Run as regular match server (0) or matchless/ffa server (1).
 set k_matchless                 0
- // use configs/usermodes/matchless instead of [...]/ffa (0 = no, 1 = yes)
+
+// k_use_matchless_dir - Use configs/usermodes/matchless instead of ../ffa.
 set k_use_matchless_dir         1
 
-// free modes
-// default mode on server
+// k_defmode - Default mode on server.
 set k_defmode                   2on2
-// allowed free modes (bit mask):
+
+// k_allowed_free_modes - Allowed free modes bitmask.
 set k_allowed_free_modes        255
-//  1=1on1, 2=2on2, 4=3on3, 8=4on4, 16=10on10, 32=ffa 64=ctf 128=hoonymode
-// server homemap. server will change to this when last player leaves the server
-// server mode (1 = duel, 2 = team, 3 = ffa, 4 = ctf)
+// 1=1on1, 2=2on2, 4=3on3, 8=4on4, 16=10on10, 32=ffa, 64=ctf, 128=hoonymode
+
+// k_defmap - Home map when server becomes empty.
 set k_defmap                    dm4
+
+// k_mode - Server mode: 1=duel, 2=team, 3=ffa, 4=ctf.
 set k_mode                      2
+
+// .............................. Map Rotation .............................. //
+
+// Rotation and mode flow are primarily managed by KTX mode configuration.
+// k_defmap above acts as the fallback map when the server becomes empty.
+// Startup behavior is controlled by server launch and KTX configuration.


### PR DESCRIPTION
## Summary
Standardizes style and section structure for Quake-family `server.cfg` files.

## What changed
- Added/normalized banner headers and section headings.
- Aligned section ordering to the Quake model where applicable.
- Improved comment consistency and fixed minor typos.
- Kept behavior unchanged (no intentional gameplay value changes).
- Avoided empty startup placeholder sections.

## Files in scope
- `q2/server.cfg`
- `q3/server.cfg`
- `q4/server.cfg`
- `ql/server.cfg`
- `qw/server.cfg`

## Notes
- Includes a small post-audit cleanup pass for wording and section placement.
- Left additional optional cvar expansion out of this PR by request.