### PR TITLE
Fix nmrih README: filename mismatch and `difficultys` typo

### DIFF
--- a/nmrih/README.md
+++ b/nmrih/README.md
@@ -4,4 +4,4 @@ This directory contains:
 
  - server.cfg - standardised config file
  - full_cvar_list.txt - full list of available command variables
- - nmrih-sv_dificulty.png - explaining the different difficultys
+ - nmrih-sv_difficulty.png - explaining the different difficulties


### PR DESCRIPTION
Line 7 of `nmrih/README.md` has two issues in one line:

1. References `nmrih-sv_dificulty.png` but the actual file in the directory is `nmrih-sv_difficulty.png` — so this reference is broken
2. `difficultys` should be `difficulties`

Both fixed in this single line edit.